### PR TITLE
Update "Get transactions": Accept bank_account_id

### DIFF
--- a/nodes/Qonto/Qonto.node.ts
+++ b/nodes/Qonto/Qonto.node.ts
@@ -666,8 +666,19 @@ if (resource === 'transactions') {
 	// -----------------------------------------
 	if (operation === 'listTransactions') {
 		const endpoint = 'transactions';
-		const iban = this.getNodeParameter('iban', i) as string;
-		query.iban = iban;
+		const accountType = this.getNodeParameter('account_type', i) as string;
+		switch (accountType) {
+			case 'bank_account_id':
+				const bankAccountId = this.getNodeParameter('bank_account_id', i) as string;
+				query.bank_account_id = bankAccountId;
+				break;
+			case 'iban':
+				const iban = this.getNodeParameter('iban', i) as string;
+				query.iban = iban;
+				break;
+			default:
+				break;
+		}
 
 		const filters = this.getNodeParameter('filters', i) as IDataObject;
 		if (!isEmpty(filters)) {

--- a/nodes/Qonto/descriptions/TransactionsDescriptions.ts
+++ b/nodes/Qonto/descriptions/TransactionsDescriptions.ts
@@ -78,6 +78,54 @@ export const transactionsOperations: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
+		displayName: 'Account type',
+		name: 'account_type',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'transactions',
+				],
+			},
+		},
+		options: [
+			{
+				name: 'Bank account',
+				value: 'bank_account_id',
+				action: 'List transactions a transactions',
+			},
+			{
+				name: 'Iban',
+				value: 'iban',
+				action: 'Show transaction a transactions',
+			},
+		],
+		default: 'iban',
+	},
+	{
+		displayName: 'Bank account',
+		name: 'bank_account_id',
+		type: 'string',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: [
+					'transactions',
+				],
+				operation: [
+					'listTransactions',
+				],
+				account_type: [
+					'bank_account_id',
+				],
+			},
+		},
+		placeholder: '018f71db-c635-78b5-b90a-ea05de98c2bf',
+		default: '',
+		description: 'Retrieve all transactions within a particular bank account',
+	},
+	{
 		displayName: 'Iban',
 		name: 'iban',
 		type: 'string',
@@ -90,11 +138,14 @@ export const transactionsOperations: INodeProperties[] = [
 				operation: [
 					'listTransactions',
 				],
+				account_type: [
+					'iban',
+				],
 			},
 		},
 		placeholder: 'FR7616798000010000005663951',
 		default: '',
-		description: 'Retrieve all transactions within a particular bank account',
+		description: 'Retrieve all transactions within a particular Iban',
 	},
 	{
 		displayName: 'Filters',


### PR DESCRIPTION
# Issue:
Impossible to get the transactions from external account because no Iban exist

# How to fix:
Switch to bank_account_id in the card

Reference: https://docs.qonto.com/api-reference/business-api/endpoints/transactions/list-transactions#parameter-bank-account-id